### PR TITLE
[HOPSWORKS-596]  Add to variables table provided and preinstalled python library names for conda envs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,3 +18,8 @@ default['conda']['base_dir']                     = "#{node['conda']['dir']}/anac
 
 default['conda']['mirror_list']                  = ""
 default['conda']['use_defaults']                 = "true"
+
+# Comma separated list of provided library names we install for users
+default['conda']['provided_lib_names']           = "hops, tfspark, pandas, tensorflow-serving-api, horovod, hopsfacets, mmlspark, numpy"
+# Comma separated list of preinstalled libraries users should not touch
+default['conda']['preinstalled_lib_names']       = "tensorflow-gpu, tensorflow, pydoop, pyspark, tensorboard"

--- a/metadata.rb
+++ b/metadata.rb
@@ -47,3 +47,11 @@ attribute "conda/mirror_list",
 attribute "conda/use_defaults",
           :description => "whether or not to add the defaults mirrors to the channels list (default yes)",
           :type => "string"
+
+attribute "conda/provided_lib_names",
+          :description => "Comma separated list of provided library names we install for users",
+          :type => "string"
+
+attribute "conda/preinstalled_lib_names",
+          :description => "Comma separated list of preinstalled libraries users should not touch",
+          :type => "string"


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-596

Used by https://github.com/logicalclocks/hopsworks-chef/pull/194
