### PR TITLE
[HOPSWORKS-679]  Create hops-system conda env out of environment file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,9 @@ default['conda']['base_dir']                     = "#{node['conda']['dir']}/anac
 default['conda']['mirror_list']                  = ""
 default['conda']['use_defaults']                 = "true"
 
+default["conda"]["default_libs"]                   = %w{ }
+#numpy hdfs3 scikit-learn matplotlib pandas
+
 # Comma separated list of provided library names we install for users
 default['conda']['provided_lib_names']           = "hops, pandas, tensorflow-serving-api, hopsfacets, mmlspark, numpy"
 # Comma separated list of preinstalled libraries users should not touch

--- a/metadata.rb
+++ b/metadata.rb
@@ -48,6 +48,10 @@ attribute "conda/use_defaults",
           :description => "whether or not to add the defaults mirrors to the channels list (default yes)",
           :type => "string"
 
+attribute "conda/default_libs",
+          :description => "Space separated list of libraries to be installed in Conda root environment",
+          :type => "string"
+
 attribute "conda/provided_lib_names",
           :description => "Comma separated list of provided library names we install for users",
           :type => "string"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -96,3 +96,10 @@ ulimit_domain node['conda']['user'] do
     value -10
   end
 end
+
+template "/home/#{node['conda']['user']}/hops-system-environment.yml" do
+  source "hops-system-environment.yml.erb"
+  user node['conda']['user']
+  group node['conda']['group']
+  mode 0750
+end

--- a/templates/default/hops-system-environment.yml.erb
+++ b/templates/default/hops-system-environment.yml.erb
@@ -1,0 +1,53 @@
+name: hops-system
+channels:
+  - http://bbc2.sics.se:8000/pkgs/main/linux-64
+  - http://bbc2.sics.se:8000/pkgs/main/noarch
+  - defaults
+dependencies:
+  - ca-certificates=2018.03.07=0
+  - certifi=2018.10.15=py27_0
+  - libedit=3.1.20170329=h6b74fdf_2
+  - libffi=3.2.1=hd88cf55_4
+  - libgcc-ng=8.2.0=hdf63c60_1
+  - libstdcxx-ng=8.2.0=hdf63c60_1
+  - ncurses=6.1=hf484d3e_0
+  - openssl=1.0.2p=h14c3975_0
+  - pip=10.0.1=py27_0
+  - python=2.7.15=h77bded6_2
+  - readline=7.0=h7b6447c_5
+  - setuptools=40.4.3=py27_0
+  - sqlite=3.25.2=h7b6447c_0
+  - tk=8.6.8=hbc83047_0
+  - wheel=0.32.2=py27_0
+  - zlib=1.2.11=ha838bed_2
+  - pip:
+    - asn1crypto==0.24.0
+    - backports.functools-lru-cache==1.5
+    - bottle==0.12.13
+    - cffi==1.11.5
+    - chardet==3.0.4
+    - cheroot==6.5.2
+    - cherrypy==17.4.0
+    - contextlib2==0.5.5
+    - cryptography==2.3.1
+    - enum34==1.1.6
+    - idna==2.7
+    - ipaddress==1.0.22
+    - ipy==0.83
+    - jaraco.functools==1.20
+    - lxml==4.2.5
+    - more-itertools==4.3.0
+    - mysql-python==1.2.5
+    - netifaces==0.10.7
+    - portend==2.3
+    - pycparser==2.19
+    - pydoop==1.2.0
+    - pyopenssl==18.0.0
+    - pytz==2018.5
+    - requests==2.20.0
+    - six==1.11.0
+    - tempora==1.13
+    - urllib3==1.24
+    - wsgiserver==1.3
+    - zc.lockfile==1.3.0
+prefix: <%= node['conda']['base_dir'] %>/envs/hops-system


### PR DESCRIPTION
[HOPSWORKS-679]  Fix pydoop installation

[HOPSWORKS-679]  Fix pydoop installation

[HOPSWORKS-679]  Fix installation of pydoop

[HOPSWORKS-679]  Fix installing kagent_utils to hops-system environment

[HOPSWORKS-679]  Fix default libraries

[HOPSWORKS-679]  Install kagent_utils from Chef cache dir

https://logicalclocks.atlassian.net/browse/HOPSWORKS-679