### PR TITLE
[HOPSWORKS-2782] Move airflow DAGs to HopsFS

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,8 +15,6 @@ default["install"]["dev_ssh_keys"]                = "false"
 # Valid values are 'aws', 'gcp', 'azure'
 default["install"]["cloud"]                       = ""
 
-default["install"]["aws"]["instance_role"]        = "false"
-
 default["install"]["aws"]["docker"]["ecr-login_dir"]  = "/root/.docker-ecr-login/"
 
 default['install']['managed_docker_registry']         = "false"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,10 +34,10 @@ default["install"]["sudoers"]["rules"]             = "true"
 default["install"]["current_version"]             = ""
 
 # Update target
-default["install"]["version"] = "2.6.0-SNAPSHOT"
+default["install"]["version"] = "3.1.0"
 
 # List of released versions
-default["install"]["versions"] = "0.1.0,0.2.0,0.3.0,0.4.0,0.4.1,0.4.2,0.5.0,0.6.0,0.6.1,0.7.0,0.8.0,0.8.1,0.9.0,0.9.1,0.10.0,1.0.0,1.1.0,1.2.0,1.3.0,1.4.0,1.4.1,2.0.0,2.1.0,2.2.0,2.3.0,2.4.0,2.5.0"
+default["install"]["versions"] = "0.1.0,0.2.0,0.3.0,0.4.0,0.4.1,0.4.2,0.5.0,0.6.0,0.6.1,0.7.0,0.8.0,0.8.1,0.9.0,0.9.1,0.10.0,1.0.0,1.1.0,1.2.0,1.3.0,1.4.0,1.4.1,2.0.0,2.1.0,2.2.0,2.3.0,2.4.0,2.5.0,3.0.0"
 
 
 # These are global attributes which are inherited by all the cookbooks and therefore available

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -73,7 +73,7 @@ default['logger']['group_id']                     = "1519"
 ############################ END GLOBAL ATTRIBUTES #######################################
 
 default['conda']['version']                       = "4.8.3"
-default['conda']['python']                        = "py37"
+default['conda']['python']                        = "py" + "#{node['install']['python']['version']}".sub('.',"")
 
 default['conda']['beam']['version']               = "2.24.0"
 default['conda']['pydoop']['version']             = "2.0.0"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,7 +71,7 @@ default['logger']['group_id']                     = "1519"
 
 # Pypi library versions
 
-default['scikit-learn']['version']                = "0.22.2.post1"  # this version needs to match the one set in docker-images (env.yml)
+default['scikit-learn']['version']                = "1.1.1"  # this version needs to match the one set in docker-images (env.yml)
 
 ############################ END GLOBAL ATTRIBUTES #######################################
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -107,6 +107,7 @@ default['conda']['base_dir']                      = "#{node['conda']['dir']}/ana
 default['conda']['hops-system']['installation-mode'] = "full"
 
 default['conda']['channels']['default_mirrors']   = ""
+default['conda']['ssl_verify']                    = "true"
 default['conda']['use_defaults']                  = "true"
 default['conda']['repodata_ttl']                  = 43200 # Cache repodata information for 12h
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,7 +59,7 @@ default['install']['enterprise']['download_url']  = nil
 default['install']['enterprise']['username']      = nil
 default['install']['enterprise']['password']      = nil
 
-default['install']['python']['version']           = "3.7"
+default['install']['python']['version']           = "3.8"
 
 default['install']['bind_services_private_ip']    = "false"
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,6 +59,8 @@ default['install']['enterprise']['download_url']  = nil
 default['install']['enterprise']['username']      = nil
 default['install']['enterprise']['password']      = nil
 
+default['install']['python']['version']           = "3.7"
+
 default['install']['bind_services_private_ip']    = "false"
 
 default['hops']['group_id']                       = "1234"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,7 +34,7 @@ default["install"]["sudoers"]["rules"]             = "true"
 default["install"]["current_version"]             = ""
 
 # Update target
-default["install"]["version"] = "3.1.0"
+default["install"]["version"] = "3.1.0-SNAPSHOT"
 
 # List of released versions
 default["install"]["versions"] = "0.1.0,0.2.0,0.3.0,0.4.0,0.4.1,0.4.2,0.5.0,0.6.0,0.6.1,0.7.0,0.8.0,0.8.1,0.9.0,0.9.1,0.10.0,1.0.0,1.1.0,1.2.0,1.3.0,1.4.0,1.4.1,2.0.0,2.1.0,2.2.0,2.3.0,2.4.0,2.5.0,3.0.0"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,10 +36,10 @@ default["install"]["sudoers"]["rules"]             = "true"
 default["install"]["current_version"]             = ""
 
 # Update target
-default["install"]["version"] = "2.5.0-SNAPSHOT"
+default["install"]["version"] = "2.6.0-SNAPSHOT"
 
 # List of released versions
-default["install"]["versions"] = "0.1.0,0.2.0,0.3.0,0.4.0,0.4.1,0.4.2,0.5.0,0.6.0,0.6.1,0.7.0,0.8.0,0.8.1,0.9.0,0.9.1,0.10.0,1.0.0,1.1.0,1.2.0,1.3.0,1.4.0,1.4.1,2.0.0,2.1.0,2.2.0,2.3.0,2.4.0"
+default["install"]["versions"] = "0.1.0,0.2.0,0.3.0,0.4.0,0.4.1,0.4.2,0.5.0,0.6.0,0.6.1,0.7.0,0.8.0,0.8.1,0.9.0,0.9.1,0.10.0,1.0.0,1.1.0,1.2.0,1.3.0,1.4.0,1.4.1,2.0.0,2.1.0,2.2.0,2.3.0,2.4.0,2.5.0"
 
 
 # These are global attributes which are inherited by all the cookbooks and therefore available

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,6 +71,10 @@ default['logger']['user_id']                      = "1524"
 default['logger']['group']                        = "logger"
 default['logger']['group_id']                     = "1519"
 
+# Pypi library versions
+
+default['scikit-learn']['version']                = "0.22.2.post1"  # this version needs to match the one set in docker-images (env.yml)
+
 ############################ END GLOBAL ATTRIBUTES #######################################
 
 default['conda']['version']                       = "4.8.3"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'jdowling@kth.se'
 license           'Apache v.2'
 description       'Installs/Configures conda'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "2.5.0"
+version           "2.6.0"
 
 supports 'ubuntu', '= 14.04'
 supports 'ubuntu', '= 16.04'

--- a/metadata.rb
+++ b/metadata.rb
@@ -141,6 +141,10 @@ attribute "conda/channels/default_mirrors",
           :description => "comma separated list of anaconda mirrors",
           :type => "string"
 
+attribute "conda/ssl_verify",
+          :description => "Set ssl_verify option in condarc - default true",
+          :type => "string"
+
 attribute "conda/use_defaults",
           :description => "whether or not to add the defaults mirrors to the channels list (default yes)",
           :type => "string"

--- a/metadata.rb
+++ b/metadata.rb
@@ -121,10 +121,6 @@ attribute "install/kubernetes",
           :description => "Set to true if you want to deploy the kubernetes enterprise edition. Default is 'fasle'",
           :type => 'string'
 
-attribute "install/aws/instance_role",
-          :description => "Set to true if using AWS and authorization should be done using the instance role",
-          :type => 'string'
-    
 attribute "install/sudoers/scripts_dir",
           :description => "Location for the Hopsworks script requiring sudoers, (default: /srv/hops/sbin)",
           :type => 'string'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'jdowling@kth.se'
 license           'Apache v.2'
 description       'Installs/Configures conda'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "2.6.0"
+version           "3.1.0"
 
 supports 'ubuntu', '= 14.04'
 supports 'ubuntu', '= 16.04'

--- a/templates/default/condarc.erb
+++ b/templates/default/condarc.erb
@@ -8,6 +8,8 @@
 # Non-url channels will be interpreted as Anaconda.org usernames
 # (this can be changed by modifying the channel_alias key; see below).
 # The default is just 'defaults'.
+ssl_verify: <%= node['conda']['ssl_verify'] %>
+
 channels:
 <% if not node['conda']['channels']['default_mirrors'].eql?("") %>
 <% node['conda']['channels']['default_mirrors'].split(',').each do |channel| %>


### PR DESCRIPTION
https://logicalclocks.atlassian.net/browse/HOPSWORKS-2782

The Python version is used in both airflow-chef and hops-hadoop-chef recipes.
We should set it here so that we only have to change it here next time we uprade the version of python again.