### PR TITLE
[HOPSWORKS-2647] Support Ubuntu 20.04 / Centos 8 (#120)

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -68,6 +68,10 @@ bash "create_hops-system_env" do
   group 'root'
   umask "022"
   cwd "/home/#{node['conda']['user']}"
+  environment (node['platform_family'].eql?("rhel") ? {
+    'CXXFLAGS':'-I/usr/include/tirpc',
+    'CFLAGS':'-I/usr/include/tirpc'
+  } : {})
   code <<-EOF
     set -e
     su #{node['conda']['user']} -c "HADOOP_HOME=#{node['install']['dir']}/hadoop PATH=#{node['install']['dir']}/hadoop/bin:$PATH \

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -7,7 +7,7 @@ if node['platform_family'].eql?("rhel") && node['rhel']['epel'].downcase == "tru
 end
 
 if node['platform_family'].eql?("rhel")
-  package "bind-utils"
+  package ["bind-utils", "libtirpc-devel"]
 end
 
 package ["bzip2", "vim", "iftop", "htop", "iotop", "rsync"]

--- a/templates/default/hops-system-environment.yml.erb
+++ b/templates/default/hops-system-environment.yml.erb
@@ -53,4 +53,5 @@ dependencies:
     - zc.lockfile==1.3.0
     - nvidia-ml-py==<%= node['conda']['nvidia-ml-py']['version'] %>
     - coloredlogs==10.0
+    - dtrx==8.2.0
 prefix: <%= node['conda']['base_dir'] %>/envs/hops-system


### PR DESCRIPTION
* Install dtrx using python in the base system

* Bump dtrx version

* Install libtirpc-devel and set correct env variables