### PR TITLE
WIP: Add spark-pit as pip dependency

### DIFF
--- a/templates/default/hops-system-environment.yml.erb
+++ b/templates/default/hops-system-environment.yml.erb
@@ -54,4 +54,5 @@ dependencies:
     - nvidia-ml-py==<%= node['conda']['nvidia-ml-py']['version'] %>
     - coloredlogs==10.0
     - dtrx==8.2.0
+    - spark-pit==0.3.0
 prefix: <%= node['conda']['base_dir'] %>/envs/hops-system

--- a/templates/default/minimal-hops-system-environment.yml.erb
+++ b/templates/default/minimal-hops-system-environment.yml.erb
@@ -52,4 +52,5 @@ dependencies:
     - zc.lockfile==1.3.0
     - nvidia-ml-py==<%= node['conda']['nvidia-ml-py']['version'] %>
     - coloredlogs==10.0
+    - spark-pit==0.3.0
 prefix: <%= node['conda']['base_dir'] %>/envs/hops-system


### PR DESCRIPTION
Add `spark-pit` Python dependency for optimized PIT joins.

Related PRs:
logicalclocks/hopsworks#1069
logicalclocks/spark-chef#147