### PR TITLE
[HWORKS-166] conda-chef ignores tmp_directory attribute when installi…

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,8 +1,5 @@
 source "https://supermarket.chef.io"
 
-
 metadata
 
-cookbook 'ulimit', github: "logicalclocks/chef-ulimit", branch: "3.0"
 cookbook 'java', github: "logicalclocks/java", branch: "v7.0.0-1"
-

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,6 @@ supports 'centos', '= 7.2'
 
 depends 'magic_shell', '~> 1.0.0'
 depends 'java'
-depends 'ulimit'
 
 recipe "conda::install", "Installs  conda"
 recipe "conda::default", "Configures conda"


### PR DESCRIPTION
…… (#137)

* [HWORKS-166] conda-chef ignores tmp_directory attribute when installing miniconda

[HWORKS-166]: https://hopsworks.atlassian.net/browse/HWORKS-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ